### PR TITLE
refactor: remove unused test flags

### DIFF
--- a/src/cli_onprem/__main__.py
+++ b/src/cli_onprem/__main__.py
@@ -8,7 +8,6 @@ from rich.console import Console
 
 from cli_onprem.commands import docker_tar, fatpack, helm
 
-is_test = "pytest" in sys.modules
 context_settings = {
     "ignore_unknown_options": True,  # Always allow unknown options
     "allow_extra_args": True,  # Always allow extra args

--- a/src/cli_onprem/commands/docker_tar.py
+++ b/src/cli_onprem/commands/docker_tar.py
@@ -1,7 +1,6 @@
 """CLI-ONPREM을 위한 Docker 이미지 tar 명령어."""
 
 import subprocess
-import sys
 import time
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
@@ -11,7 +10,6 @@ from rich.console import Console
 from rich.prompt import Confirm
 from typing_extensions import Annotated
 
-is_test = "pytest" in sys.modules
 context_settings = {
     "ignore_unknown_options": True,  # Always allow unknown options
     "allow_extra_args": True,  # Always allow extra args

--- a/src/cli_onprem/commands/fatpack.py
+++ b/src/cli_onprem/commands/fatpack.py
@@ -2,7 +2,6 @@
 
 import os
 import subprocess
-import sys
 from pathlib import Path
 from typing import List, Optional
 
@@ -11,7 +10,6 @@ from rich.console import Console
 from rich.markup import escape
 from typing_extensions import Annotated
 
-is_test = "pytest" in sys.modules
 context_settings = {
     "ignore_unknown_options": True,  # Always allow unknown options
     "allow_extra_args": True,  # Always allow extra args

--- a/src/cli_onprem/commands/helm.py
+++ b/src/cli_onprem/commands/helm.py
@@ -15,7 +15,6 @@ import yaml
 from rich.console import Console
 from typing_extensions import Annotated
 
-is_test = "pytest" in sys.modules
 context_settings = {
     "ignore_unknown_options": True,  # Always allow unknown options
     "allow_extra_args": True,  # Always allow extra args


### PR DESCRIPTION
## Summary
- remove unused `is_test` variables
- run `ruff` to fix imports

## Testing
- `ruff check src tests`
- `pytest -q tests/test_fatpack.py` *(fails: command not found)*