### PR TITLE
Add arch choice validation

### DIFF
--- a/docs/docker_tar.md
+++ b/docs/docker_tar.md
@@ -11,7 +11,7 @@ cli-onprem docker-tar save <reference> [OPTIONS]
 ## 옵션
 
 - `<reference>`: 필수. 컨테이너 이미지 레퍼런스 (형식: `[<registry>/][<namespace>/]<image>[:<tag>]`).
-- `--arch <os/arch>`: 선택 사항. 추출 플랫폼 지정 (예: `linux/arm64`). 기본값: 자동 감지 (amd64로 설정됨).
+- `--arch <os/arch>`: 선택 사항. 추출 플랫폼 지정. 허용 값은 `linux/amd64` 또는 `linux/arm64`이며 기본값은 `linux/amd64`.
 - `--output`, `-o <dir|file>`: 선택 사항. 저장 위치(디렉터리 또는 완전한 경로). 기본값: 현재 작업 디렉터리.
 - `--stdout`: 선택 사항. tar 스트림을 표준 출력으로 내보냄 (파이프용).
 - `--force`, `-f`: 선택 사항. 동일 이름 파일 덮어쓰기. 기본값: False.

--- a/src/cli_onprem/commands/docker_tar.py
+++ b/src/cli_onprem/commands/docker_tar.py
@@ -48,7 +48,33 @@ REFERENCE_ARG = Annotated[
         autocompletion=complete_docker_reference,
     ),
 ]
-ARCH_OPTION = typer.Option(None, "--arch", help="추출 플랫폼 지정 (linux/arm64 등)")
+
+
+def _validate_arch(value: str) -> str:
+    """`--arch` 옵션 값을 검증한다.
+
+    Args:
+        value: 사용자가 입력한 플랫폼 문자열.
+
+    Returns:
+        검증된 플랫폼 문자열.
+
+    Raises:
+        typer.BadParameter: 허용되지 않은 값이 입력된 경우.
+    """
+    allowed = {"linux/amd64", "linux/arm64"}
+    if value not in allowed:
+        msg = "linux/amd64 또는 linux/arm64만 지원합니다."
+        raise typer.BadParameter(msg)
+    return value
+
+
+ARCH_OPTION = typer.Option(
+    "linux/amd64",
+    "--arch",
+    help="추출 플랫폼 지정 (linux/amd64 또는 linux/arm64)",
+    callback=_validate_arch,
+)
 OUTPUT_OPTION = typer.Option(
     None, "--output", "-o", help="저장 위치(디렉터리 또는 완전한 경로)"
 )

--- a/tests/test_docker_tar.py
+++ b/tests/test_docker_tar.py
@@ -120,3 +120,14 @@ def test_pull_image_with_arch() -> None:
             stderr=subprocess.PIPE,
             text=True,
         )
+
+
+def test_save_invalid_arch() -> None:
+    """Invalid arch option should return an error."""
+    result = runner.invoke(
+        app,
+        ["docker-tar", "save", "nginx", "--arch", "linux/ppc64"],
+    )
+
+    assert result.exit_code != 0
+    assert "linux/amd64 또는 linux/arm64만 지원합니다." in result.stdout


### PR DESCRIPTION
## Summary
- validate docker-tar `--arch` option
- document valid architecture options
- test invalid arch handling

## Testing
- `black --check src/cli_onprem/commands/docker_tar.py tests/test_docker_tar.py`
- `ruff check .`
- `mypy src`
- *Tests not run: pytest unavailable*
