### PR TITLE
Restrict CI to src and tests changes only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/ci.yml'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- remove changed-file check from CI workflow
- rely solely on `paths` filter for triggering CI

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: command not found)*