### PR TITLE
Fix cache file encoding

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -35,6 +35,8 @@ def complete_bucket(incomplete: str) -> List[str]:
 
 캐시 파일은 다음과 같은 JSON 구조로 저장됩니다:
 
+모든 캐시 파일은 **UTF-8 인코딩**으로 저장됩니다.
+
 ```json
 {
   "timestamp": 1621234567,  // 마지막 갱신 시간 (Unix 타임스탬프)

--- a/src/cli_onprem/libs/cache.py
+++ b/src/cli_onprem/libs/cache.py
@@ -34,7 +34,7 @@ def read_cache(cache_name: str) -> Optional[Dict[str, Any]]:
         return None
 
     try:
-        with open(cache_path) as f:
+        with open(cache_path, encoding="utf-8") as f:
             result: Dict[str, Any] = json.load(f)
             return result
     except (json.JSONDecodeError, OSError):
@@ -48,7 +48,7 @@ def write_cache(cache_name: str, data: Any, ttl: int = DEFAULT_TTL) -> None:
     cache_data = {"timestamp": int(time.time()), "data": data, "ttl": ttl}
 
     try:
-        with open(cache_path, "w") as f:
+        with open(cache_path, "w", encoding="utf-8") as f:
             json.dump(cache_data, f)
         os.chmod(cache_path, 0o600)
     except OSError:


### PR DESCRIPTION
## Summary
- open cache files with UTF-8 encoding
- document that cache files are UTF-8 encoded

## Testing
- `pre-commit run --files docs/cache.md src/cli_onprem/libs/cache.py` *(fails: `pre-commit: command not found`)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*