### PR TITLE
Remove cache usage from docker_tar

### DIFF
--- a/src/cli_onprem/commands/docker_tar.py
+++ b/src/cli_onprem/commands/docker_tar.py
@@ -58,9 +58,7 @@ def complete_docker_reference(incomplete: str) -> List[str]:
             console.print(f"[yellow]이미지 자동완성 오류: {e}[/yellow]")
             return []
 
-    from cli_onprem.libs.cache import get_cached_data
-
-    all_images = get_cached_data("docker_images", fetch_docker_images, ttl=300)
+    all_images = fetch_docker_images()
 
     registry_filter = None
     if "/" in incomplete:


### PR DESCRIPTION
## Summary
- remove cached image lookup in docker_tar completion

## Testing
- `ruff check src/cli_onprem/commands/docker_tar.py`
- `ruff format src/cli_onprem/commands/docker_tar.py`
- `black --check src/cli_onprem/commands/docker_tar.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*