### PR TITLE
Update size file example

### DIFF
--- a/docs/tar-fat32.md
+++ b/docs/tar-fat32.md
@@ -89,7 +89,7 @@ movie.iso.pack/
 │  └─ 0003.part
 ├─ manifest.sha256
 ├─ restore.sh
-└─ size.txt
+└─ <size>_MB
 ```
 
 #### 복원 과정
@@ -108,7 +108,7 @@ movie.iso.pack/
 │   └─ …
 ├─ manifest.sha256
 ├─ restore.sh
-└─ size.txt
+└─ <size>_MB
 
 movie.iso          ← 상위 디렉터리에 원본이 생성되었음
 ```


### PR DESCRIPTION
## Summary
- update the tar-fat32 docs to use `<size>_MB` instead of `size.txt`

## Testing
- `ruff check .`
- `black --check .`
- `mypy src`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*