### PR TITLE
Add destination option for docker-tar

### DIFF
--- a/docs/docker_tar.md
+++ b/docs/docker_tar.md
@@ -12,7 +12,7 @@ cli-onprem docker-tar save <reference> [OPTIONS]
 
 - `<reference>`: 필수. 컨테이너 이미지 레퍼런스 (형식: `[<registry>/][<namespace>/]<image>[:<tag>]`).
 - `--arch <os/arch>`: 선택 사항. 추출 플랫폼 지정. 허용 값은 `linux/amd64` 또는 `linux/arm64`이며 기본값은 `linux/amd64`.
-- `--output`, `-o <dir|file>`: 선택 사항. 저장 위치(디렉터리 또는 완전한 경로). 기본값: 현재 작업 디렉터리.
+- `--destination`, `-d <dir|file>`: 선택 사항. 저장 위치(디렉터리 또는 완전한 경로). 기본값: 현재 작업 디렉터리. 디렉터리가 없으면 생성합니다.
 - `--stdout`: 선택 사항. tar 스트림을 표준 출력으로 내보냄 (파이프용).
 - `--force`, `-f`: 선택 사항. 동일 이름 파일 덮어쓰기. 기본값: False.
 - `--quiet`, `-q`: 선택 사항. 에러만 출력. 기본값: False.
@@ -55,7 +55,7 @@ cli-onprem docker-tar save ghcr.io/bitnami/redis:7.2.4 --arch linux/arm64
 # 출력: ./ghcr.io__bitnami__redis__7.2.4__arm64.tar 생성
 
 # 절대 경로 지정
-cli-onprem docker-tar save alpine:3.20 --output /var/backup
+cli-onprem docker-tar save alpine:3.20 --destination /var/backup
 # 출력: /var/backup/alpine__3.20__amd64.tar 생성
 
 # 파이프-압축

--- a/docs/helm-local.md
+++ b/docs/helm-local.md
@@ -74,10 +74,10 @@ cli-onprem helm-local extract-images prometheus-22.6.1.tgz --json
 
 ```bash
 # 모든 이미지를 추출하여 tar 파일로 저장
-cli-onprem helm-local extract-images nginx-13.2.0.tgz | xargs -n1 cli-onprem docker-tar save -o /path/to/images/
+cli-onprem helm-local extract-images nginx-13.2.0.tgz | xargs -n1 cli-onprem docker-tar save -d /path/to/images/
 
 # 특정 values 파일을 적용하여 이미지 추출 후 저장
-cli-onprem helm-local extract-images wordpress-15.2.35.tgz -f prod-values.yaml | xargs -n1 cli-onprem docker-tar save -o /path/to/images/
+cli-onprem helm-local extract-images wordpress-15.2.35.tgz -f prod-values.yaml | xargs -n1 cli-onprem docker-tar save -d /path/to/images/
 ```
 
 이 방식으로 Helm 차트에서 사용되는 모든 이미지를 자동으로 추출하여 tar 파일로 저장할 수 있습니다.

--- a/src/cli_onprem/commands/docker_tar.py
+++ b/src/cli_onprem/commands/docker_tar.py
@@ -118,8 +118,11 @@ ARCH_OPTION = typer.Option(
     callback=_validate_arch,
     autocompletion=complete_arch,
 )
-OUTPUT_OPTION = typer.Option(
-    None, "--output", "-o", help="저장 위치(디렉터리 또는 완전한 경로)"
+DEST_OPTION = typer.Option(
+    None,
+    "--destination",
+    "-d",
+    help="저장 위치(디렉터리 또는 완전한 경로)",
 )
 STDOUT_OPTION = typer.Option(
     False, "--stdout", help="tar 스트림을 표준 출력으로 내보냄"
@@ -271,7 +274,7 @@ def save(
         ),
     ],
     arch: str = ARCH_OPTION,
-    output: Optional[Path] = OUTPUT_OPTION,
+    destination: Optional[Path] = DEST_OPTION,
     stdout: bool = STDOUT_OPTION,
     force: bool = FORCE_OPTION,
     quiet: bool = QUIET_OPTION,
@@ -291,11 +294,16 @@ def save(
 
     filename = generate_filename(registry, namespace, image, tag, architecture)
 
-    output_path = Path.cwd() if output is None else output
-    if output_path.is_dir():
-        full_path = output_path / filename
+    dest_path = Path.cwd() if destination is None else destination
+
+    if destination is None or (
+        dest_path.is_dir() or (not dest_path.exists() and not dest_path.suffix)
+    ):
+        if not dest_path.exists():
+            dest_path.mkdir(parents=True, exist_ok=True)
+        full_path = dest_path / filename
     else:
-        full_path = output_path
+        full_path = dest_path
 
     if verbose:
         console.print(f"[bold blue]레퍼런스: {reference}[/bold blue]")


### PR DESCRIPTION
## Summary
- update docs for new `--destination` option
- allow `docker-tar save` to create destination directory
- rename tests accordingly and cover directory creation

## Testing
- `ruff check src/cli_onprem/commands/docker_tar.py tests/test_docker_tar_extended.py`
- `black src/cli_onprem/commands/docker_tar.py tests/test_docker_tar_extended.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*