### PR TITLE
refactor: docker-tar를 함수형 아키텍처로 리팩토링

### DIFF
--- a/src/cli_onprem/commands/docker_tar.py
+++ b/src/cli_onprem/commands/docker_tar.py
@@ -1,15 +1,25 @@
 """CLI-ONPREM을 위한 Docker 이미지 tar 명령어."""
 
-import shutil
-import subprocess
-import time
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional
 
 import typer
 from rich.console import Console
 from rich.prompt import Confirm
 from typing_extensions import Annotated
+
+from cli_onprem.core.errors import CommandError, DependencyError
+from cli_onprem.core.logging import get_logger, init_logging, set_log_level
+from cli_onprem.services.docker import (
+    check_docker_installed,
+    generate_tar_filename,
+    list_local_images,
+    parse_image_reference,
+    pull_image,
+    save_image,
+    save_image_to_stdout,
+)
+from cli_onprem.utils.shell import check_command_exists
 
 context_settings = {
     "ignore_unknown_options": True,  # Always allow unknown options
@@ -21,44 +31,27 @@ app = typer.Typer(
     context_settings=context_settings,
 )
 console = Console()
+logger = get_logger("commands.docker_tar")
 
 
-def check_docker_cli_installed() -> None:
-    """Docker CLI가 설치되어 있는지 확인합니다.
-
-    설치되어 있지 않은 경우 안내 메시지를 출력하고 프로그램을 종료합니다.
-    """
-    if shutil.which("docker") is None:
-        console.print("[bold red]오류: Docker CLI가 설치되어 있지 않습니다[/bold red]")
-        console.print(
-            "[yellow]Docker CLI 설치 방법: https://docs.docker.com/engine/install/[/yellow]"
-        )
-        raise typer.Exit(code=1)
+def _check_docker_cli() -> None:
+    """Docker CLI 설치 확인 및 에러 처리."""
+    try:
+        check_docker_installed()
+    except DependencyError as e:
+        console.print(f"[bold red]오류: {e}[/bold red]")
+        raise typer.Exit(code=1) from e
 
 
 def complete_docker_reference(incomplete: str) -> List[str]:
     """도커 이미지 레퍼런스 자동완성: 로컬에 있는 이미지 제안"""
+    if not check_command_exists("docker"):
+        return []
 
-    def fetch_docker_images() -> List[str]:
-        if shutil.which("docker") is None:
-            console.print(
-                "[yellow]Docker CLI가 없어 자동완성을 제공할 수 없습니다[/yellow]"
-            )
-            return []  # Docker CLI가 없으면 자동완성 제안 없음
-
-        try:
-            result = subprocess.run(
-                ["docker", "images", "--format", "{{.Repository}}:{{.Tag}}"],
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            return result.stdout.splitlines()
-        except Exception as e:
-            console.print(f"[yellow]이미지 자동완성 오류: {e}[/yellow]")
-            return []
-
-    all_images = fetch_docker_images()
+    try:
+        all_images = list_local_images()
+    except CommandError:
+        return []
 
     registry_filter = None
     if "/" in incomplete:
@@ -135,133 +128,7 @@ DRY_RUN_OPTION = typer.Option(
 VERBOSE_OPTION = typer.Option(False, "--verbose", "-v", help="DEBUG 로그 출력")
 
 
-def parse_image_reference(reference: str) -> Tuple[str, str, str, str]:
-    """Docker 이미지 레퍼런스를 분해합니다.
-
-    형식: [<registry>/][<namespace>/]<image>[:<tag>]
-    누락 시 기본값:
-    - registry: docker.io
-    - namespace: library
-    - tag: latest
-    """
-    registry = "docker.io"
-    namespace = "library"
-    image = ""
-    tag = "latest"
-
-    if ":" in reference:
-        ref_parts = reference.split(":")
-        tag = ref_parts[-1]
-        reference = ":".join(ref_parts[:-1])
-
-    parts = reference.split("/")
-
-    if len(parts) == 1:
-        image = parts[0]
-    elif len(parts) == 2:
-        if "." in parts[0] or ":" in parts[0]:  # 레지스트리로 판단
-            registry = parts[0]
-            image = parts[1]
-        else:  # 네임스페이스/이미지로 판단
-            namespace = parts[0]
-            image = parts[1]
-    elif len(parts) >= 3:
-        registry = parts[0]
-        namespace = parts[1]
-        image = "/".join(parts[2:])
-
-    return registry, namespace, image, tag
-
-
-def generate_filename(
-    registry: str, namespace: str, image: str, tag: str, arch: str
-) -> str:
-    """이미지 정보를 기반으로 파일명을 생성합니다.
-
-    형식: [reg__][ns__]image__tag__arch.tar
-    """
-    registry = registry.replace("/", "_")
-    namespace = namespace.replace("/", "_")
-    image = image.replace("/", "_")
-    tag = tag.replace("/", "_")
-    arch = arch.replace("/", "_")
-
-    parts = []
-
-    if registry != "docker.io":
-        parts.append(f"{registry}__")
-
-    if namespace != "library":
-        parts.append(f"{namespace}__")
-
-    parts.append(f"{image}__{tag}__{arch}.tar")
-
-    return "".join(parts)
-
-
-def check_image_exists(reference: str) -> bool:
-    """이미지가 로컬에 존재하는지 확인합니다."""
-    cmd = ["docker", "inspect", "--type=image", reference]
-    try:
-        subprocess.run(
-            cmd,
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        return True
-    except subprocess.CalledProcessError:
-        return False
-
-
-def pull_image(
-    reference: str, quiet: bool = False, max_retries: int = 3, arch: str = "linux/amd64"
-) -> Tuple[bool, str]:
-    """이미지를 Docker Hub에서 가져옵니다."""
-    if not quiet:
-        console.print(f"[yellow]이미지 {reference} 다운로드 중...[/yellow]")
-    cmd = ["docker", "pull", "--platform", arch, reference]
-
-    retry_count = 0
-    last_error = ""
-
-    while retry_count <= max_retries:
-        success, error = run_docker_command(cmd)
-        if success:
-            return True, ""
-
-        last_error = error
-        if isinstance(error, bytes):
-            error_str = error.decode("utf-8", errors="replace")
-        else:
-            error_str = str(error)
-
-        if "timeout" in error_str.lower() and retry_count < max_retries:
-            retry_count += 1
-            wait_time = 2**retry_count  # 지수 백오프 (2, 4, 8초)
-            if not quiet:
-                console.print(
-                    f"[yellow]이미지 다운로드 타임아웃, {retry_count}/{max_retries} "
-                    f"재시도 중 ({wait_time}초 대기)...[/yellow]"
-                )
-            time.sleep(wait_time)
-        else:
-            break
-
-    return False, last_error
-
-
-def run_docker_command(
-    cmd: List[str], stdout: Optional[Any] = None
-) -> Tuple[bool, str]:
-    """Docker 명령어를 실행합니다."""
-    try:
-        subprocess.run(
-            cmd, check=True, stdout=stdout, stderr=subprocess.PIPE, text=True
-        )
-        return True, ""
-    except subprocess.CalledProcessError as e:
-        return False, e.stderr
+# 삭제 - 서비스 모듈로 이동
 
 
 @app.command()
@@ -285,14 +152,23 @@ def save(
 
     이미지 레퍼런스 구문: [<registry>/][<namespace>/]<image>[:<tag>]
     """
-    check_docker_cli_installed()  # Docker CLI 의존성 확인
+    # 로깅 초기화
+    init_logging()
+
+    if quiet:
+        set_log_level("ERROR")
+    elif verbose:
+        set_log_level("DEBUG")
+
+    _check_docker_cli()  # Docker CLI 의존성 확인
+
     registry, namespace, image, tag = parse_image_reference(reference)
 
     architecture = "amd64"
     if arch:
         architecture = arch.split("/")[-1]  # linux/arm64 -> arm64
 
-    filename = generate_filename(registry, namespace, image, tag, architecture)
+    filename = generate_tar_filename(registry, namespace, image, tag, architecture)
 
     dest_path = Path.cwd() if destination is None else destination
 
@@ -325,29 +201,23 @@ def save(
             console.print("[yellow]작업이 취소되었습니다.[/yellow]")
             return
 
-    if verbose:
-        console.print(f"[blue]이미지 {reference} 다운로드 중...[/blue]")
+    try:
+        # 이미지 pull
+        pull_image(reference, arch=f"linux/{architecture}")
 
-    success, error = pull_image(reference, quiet, arch=f"linux/{architecture}")
-    if not success:
-        console.print(f"[bold red]Error: 이미지 다운로드 실패: {error}[/bold red]")
-        raise typer.Exit(code=1)
+        if not quiet:
+            console.print(f"[green]이미지 {reference} 저장 중...[/green]")
 
-    if not quiet:
-        console.print(f"[green]이미지 {reference} 저장 중...[/green]")
-
-    if stdout:
-        docker_cmd = ["docker", "save", reference]
-        success, error = run_docker_command(docker_cmd, stdout=subprocess.STDOUT)
-    else:
-        docker_cmd = ["docker", "save", "-o", str(full_path), reference]
-        success, error = run_docker_command(docker_cmd)
-
-    if not success:
-        console.print(f"[bold red]Error: {error}[/bold red]")
-        raise typer.Exit(code=1)
-
-    if not stdout and not quiet:
-        console.print(
-            f"[bold green]이미지가 성공적으로 저장되었습니다: {full_path}[/bold green]"
-        )
+        # 이미지 저장
+        if stdout:
+            save_image_to_stdout(reference)
+        else:
+            save_image(reference, str(full_path))
+            if not quiet:
+                console.print(
+                    f"[bold green]이미지가 성공적으로 저장되었습니다: "
+                    f"{full_path}[/bold green]"
+                )
+    except (CommandError, DependencyError) as e:
+        console.print(f"[bold red]Error: {e}[/bold red]")
+        raise typer.Exit(code=1) from e

--- a/src/cli_onprem/core/errors.py
+++ b/src/cli_onprem/core/errors.py
@@ -16,6 +16,18 @@ class CLIError(Exception):
         self.exit_code = exit_code
 
 
+class CommandError(CLIError):
+    """명령 실행 중 발생하는 에러."""
+
+    pass
+
+
+class DependencyError(CLIError):
+    """의존성 관련 에러."""
+
+    pass
+
+
 def handle_error(error: Exception, exit_code: int = 1) -> None:
     """에러를 처리하고 적절한 메시지를 출력합니다.
 

--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,7 @@ wheels = [
 
 [[package]]
 name = "cli-onprem"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
- Docker 작업을 services/docker.py로 분리하여 재사용성 향상
- commands/docker_tar.py를 354줄에서 220줄로 축소
- CommandError와 DependencyError를 core/errors.py에 추가
- 새로운 구조에 맞게 테스트 코드 업데이트
- helm-local과 일관된 함수형 아키텍처 적용

🤖 Generated with [Claude Code](https://claude.ai/code)