### PR TITLE
feat: helm-local extract-images에 --skip-dependency-update 옵션 추가

### DIFF
--- a/src/cli_onprem/commands/helm_local.py
+++ b/src/cli_onprem/commands/helm_local.py
@@ -77,6 +77,11 @@ JSON_OPTION = typer.Option(False, "--json", help="JSON 배열 형식으로 출�
 RAW_OPTION = typer.Option(
     False, "--raw", help="이미지 이름 표준화 없이 원본 그대로 출력"
 )
+SKIP_DEPENDENCY_UPDATE_OPTION = typer.Option(
+    False,
+    "--skip-dependency-update",
+    help="차트 의존성 업데이트를 건너뛰고 빠르게 실행",
+)
 
 
 @app.command()
@@ -92,6 +97,7 @@ def extract_images(
     quiet: bool = QUIET_OPTION,
     json_output: bool = JSON_OPTION,
     raw: bool = RAW_OPTION,
+    skip_dependency_update: bool = SKIP_DEPENDENCY_UPDATE_OPTION,
 ) -> None:
     """Helm 차트에서 사용되는 Docker 이미지 참조를 추출합니다.
 
@@ -119,7 +125,8 @@ def extract_images(
             chart_root = helm.prepare_chart(chart, workdir)
 
             # 의존성 업데이트
-            helm.update_dependencies(chart_root)
+            if not skip_dependency_update:
+                helm.update_dependencies(chart_root)
 
             # 템플릿 렌더링
             rendered = helm.render_template(chart_root, values)

--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,7 @@ wheels = [
 
 [[package]]
 name = "cli-onprem"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Summary
- helm-local extract-images 명령에 `--skip-dependency-update` 옵션 추가
- 의존성 업데이트를 건너뛰고 빠르게 이미지를 추출할 수 있음
- 기본 동작은 변경 없음 (의존성 업데이트 수행)

## Test plan
- [x] TDD 방식으로 개발 (테스트 먼저 작성)
- [x] 새로운 옵션 관련 테스트 추가
- [x] 기존 테스트 모두 통과
- [x] 린트 및 타입 체크 통과

🤖 Generated with [Claude Code](https://claude.ai/code)