### PR TITLE
fix: apply LONG_TIMEOUT to s3-share sync command

### DIFF
--- a/src/cli_onprem/commands/s3_share.py
+++ b/src/cli_onprem/commands/s3_share.py
@@ -303,7 +303,11 @@ def sync(
 
     try:
         # AWS CLI 설치 확인
-        from cli_onprem.utils.shell import check_command_exists, run_command
+        from cli_onprem.utils.shell import (
+            LONG_TIMEOUT,
+            check_command_exists,
+            run_command,
+        )
 
         if not check_command_exists("aws"):
             console.print(
@@ -347,7 +351,7 @@ def sync(
         env["AWS_SECRET_ACCESS_KEY"] = creds["aws_secret_key"]
 
         # AWS CLI 실행
-        run_command(cmd, env=env)
+        run_command(cmd, env=env, timeout=LONG_TIMEOUT)
 
         console.print("[bold green]동기화 완료[/bold green]")
 

--- a/tests/test_s3_share.py
+++ b/tests/test_s3_share.py
@@ -107,6 +107,34 @@ def test_init_command_with_existing_profile_no_overwrite(
             assert credentials["test_profile"]["aws_access_key"] == "existing_key"
 
 
+def test_sync_command_uses_long_timeout(
+    mock_home_dir: Path,
+    mock_credentials: Path,
+    tmp_path: Path,
+) -> None:
+    """sync 명령어가 LONG_TIMEOUT을 사용하는지 테스트합니다."""
+    # 테스트용 파일 생성
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("test content")
+
+    with (
+        mock.patch("cli_onprem.utils.shell.check_command_exists", return_value=True),
+        mock.patch("cli_onprem.utils.shell.run_command") as mock_run_command,
+    ):
+        runner.invoke(
+            app,
+            ["s3-share", "sync", str(test_file), "--profile", "default"],
+        )
+
+        # run_command가 호출되었는지 확인
+        assert mock_run_command.called
+        # timeout 파라미터가 전달되었는지 확인
+        call_kwargs = mock_run_command.call_args.kwargs
+        assert "timeout" in call_kwargs
+        # LONG_TIMEOUT (기본값 1800) 이 전달되어야 함
+        assert call_kwargs["timeout"] == 1800
+
+
 def test_init_command_with_existing_profile_overwrite(mock_home_dir: Path) -> None:
     """기존 프로파일이 있을 때 덮어쓰기 테스트."""
     config_dir = mock_home_dir / ".cli-onprem"


### PR DESCRIPTION
## Summary
- `s3-share sync` 명령에서 `run_command()` 호출 시 `timeout` 파라미터가 누락되어 `CLI_ONPREM_LONG_TIMEOUT` 환경변수가 무시되는 버그 수정
- `LONG_TIMEOUT` import 추가 및 `run_command()` 호출에 `timeout=LONG_TIMEOUT` 파라미터 적용

## Test plan
- [x] `pytest tests/test_s3_share.py -v` 통과
- [x] `pre-commit run --all-files` 통과
- [ ] 수동 테스트: `CLI_ONPREM_LONG_TIMEOUT=10 cli-onprem s3-share sync <path>` 실행 후 10초 타임아웃 발생 확인

🤖 Generated with [Claude Code](https://claude.ai/code)